### PR TITLE
feat: Ided implements Deref

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ assert_eq!(
 assert_eq!(customer.entity().name, "John");
 ```
 
+An ided automatically derefs into the entity type, so this is valid too:
+
+```rust
+assert_eq!(customer.name, "John");
+```
+
 ## Serde
 
 An `Ided` object is serialized with the id next to the other fields, without unnecessary nesting.
@@ -118,7 +124,7 @@ assert_eq!(
     customer.id().to_string(),
     "Cust_371c35ec-34d9-4315-ab31-7ea8889a419a"
 );
-assert_eq!(customer.entity().name, "John");
+assert_eq!(customer.name, "John");
 ```
 
 The id kind is checked, the deserialization below fails because the prefix of the id is wrong:

--- a/src/ided.rs
+++ b/src/ided.rs
@@ -99,3 +99,10 @@ impl<T: Identifiable, E> AsRef<E> for Ided<T, E> {
         &self.entity
     }
 }
+
+impl<T: Identifiable, E> std::ops::Deref for Ided<T, E> {
+    type Target = E;
+    fn deref(&self) -> &Self::Target {
+        &self.entity
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ fn test_id_ided() {
     // Give it an id, by wrapping it in an Ided
     let customer = Ided::new(id, new_customer);
 
-    assert_eq!(customer.entity().name, "John");
+    assert_eq!(customer.name, "John");
     assert_eq!(
         customer.id().to_string(),
         "Cust_371c35ec-34d9-4315-ab31-7ea8889a419a"
@@ -161,5 +161,10 @@ fn test_serde() {
         "name": "John"
     }"#;
     assert!(serde_json::from_str::<Ided<Customer>>(&json).is_err());
+
+    assert_eq!(
+        serde_json::to_string(&customer).unwrap(),
+        r#"{"id":"Cust_371c35ec-34d9-4315-ab31-7ea8889a419a","name":"John"}"#,
+    );
 
 }


### PR DESCRIPTION
This makes it possible to omit the `.entity()` when using an `Ided`.