### PR TITLE
Rename the derive from "Kind" to "Identifiable"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+
+### next
+- renamed the derive from "Kind" to "Identifiable"
+
+### v0.2.0 - 2024-02-08
+<a name="0.2.0"></a>
+- Ided<O> implements Deref<O>
+- Documentation
+
+### v0.1.0 - 2024-02-05
+<a name="0.1.0"></a>
+- first public version

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ You could implement the `Identifiable` trait, but the easiest solution is to jus
 ```rust
 use kind::*;
 
-#[derive(Kind)]
+#[derive(Identifiable)]
 #[kind(class="Cust")]
 pub struct Customer {
     // many fields
 }
 
-#[derive(Kind)]
+#[derive(Identifiable)]
 #[kind(class="Cont")]
 pub struct Contract {
     // many fields
@@ -122,7 +122,7 @@ assert_eq!(customer.name, "John");
 An `Ided` object is serialized with the id next to the other fields, without unnecessary nesting.
 
 ```rust
-#[derive(Kind, serde::Serialize, serde::Deserialize)]
+#[derive(Identifiable, serde::Serialize, serde::Deserialize)]
 #[kind(class="Cust")]
 pub struct Customer {
     pub name: String,
@@ -161,7 +161,7 @@ As for serde, `FromRow` implementation on `Ided` is automatically deduced from t
 So you will usually just declare your struct like this to have the `Ided` loaded from an `sqlx::Row` containing both the `id` column and the ones of the raw struct:
 
 ```rust
-#[derive(Kind, sqlx::FromRow)]
+#[derive(Identifiable, sqlx::FromRow)]
 #[kind(class="Cust")]
 pub struct Customer {
     pub name: String,
@@ -172,7 +172,7 @@ pub struct Customer {
 If you are generating JSON schema for your objects using [schemars crate](https://crates.io/crates/schemars), you can enable `jsonschema` feature, and we will generate definition for the `Id` object and any `Ided` object:
 
 ```rust
-#[derive(JsonSchema, Kind)]
+#[derive(JsonSchema, Identifiable)]
 #[kind(class="Cust")]
 pub struct Customer {
     pub name: String

--- a/doc/a-kind-introduction.md
+++ b/doc/a-kind-introduction.md
@@ -64,7 +64,7 @@ We declare a class for each kind of object.
 This is done with a derive attribute. To say that a `Customer` has an id prefixed with `Cust_`, we write this:
 
 ```
-#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, Kind)]
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, Identifiable)]
 #[kind(class = "Cust")]
 pub struct Customer {
     pub name: String,
@@ -177,7 +177,7 @@ We use [sqlx](https://github.com/launchbadge/sqlx), so we've added some impl to 
 You may have missed the tiny `sqlx::FromRow` in the Customer definition above, so here it is again:
 
 ```
-#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, Kind)]
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, Identifiable)]
 #[kind(class = "Cust")]
 pub struct Customer {
     pub name: String,

--- a/kind_proc/src/lib.rs
+++ b/kind_proc/src/lib.rs
@@ -11,7 +11,7 @@ struct Opts {
     class: String,
 }
 
-#[proc_macro_derive(Kind, attributes(kind))]
+#[proc_macro_derive(Identifiable, attributes(kind))]
 pub fn kind_macro_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input);
     let opts = Opts::from_derive_input(&input).expect("Wrong options");

--- a/src/id.rs
+++ b/src/id.rs
@@ -130,7 +130,7 @@ impl<O: Identifiable> Hash for Id<O> {
 
 #[test]
 fn id_sorting() {
-    #[derive(Debug, Kind)]
+    #[derive(Debug, Identifiable)]
     #[kind(class = "Ex")]
     pub struct E {}
 

--- a/src/id_enum.rs
+++ b/src/id_enum.rs
@@ -6,11 +6,11 @@
 /// use kind::*;
 ///
 /// // Declare 2 types
-/// #[derive(Debug, Kind)]
+/// #[derive(Debug, Identifiable)]
 /// #[kind(class="Dog")]
 /// pub struct Dog {}
 ///
-/// #[derive(Debug, Kind)]
+/// #[derive(Debug, Identifiable)]
 /// #[kind(class="Cat")]
 /// pub struct Cat {}
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,13 @@
 //! // The structs we want to define Id types for are just annotated. The
 //! // Identifiable trait is derived.
 //!
-//! #[derive(Debug, Kind)]
+//! #[derive(Debug, Identifiable)]
 //! #[kind(class="Cust")]
 //! pub struct Customer {
 //!     // many fields
 //! }
 //!
-//! #[derive(Debug, Kind)]
+//! #[derive(Debug, Identifiable)]
 //! #[kind(class="Cont")]
 //! pub struct Contract {
 //!     // many fields
@@ -88,13 +88,13 @@ pub use crate::openapi::*;
 
 #[test]
 fn test_id_ided() {
-    #[derive(Debug, Kind)]
+    #[derive(Debug, Identifiable)]
     #[kind(class = "Cust")]
     pub struct Customer {
         pub name: String,
     }
 
-    #[derive(Debug, Kind)]
+    #[derive(Debug, Identifiable)]
     #[kind(class = "Cont")]
     pub struct Contract {
         // many fields
@@ -144,7 +144,7 @@ fn test_id_ided() {
 #[test]
 fn test_serde() {
     // deserialize a customer
-    #[derive(Debug, Kind, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Identifiable, serde::Serialize, serde::Deserialize)]
     #[kind(class = "Cust")]
     pub struct Customer {
         pub name: String,
@@ -174,5 +174,4 @@ fn test_serde() {
         serde_json::to_string(&customer).unwrap(),
         r#"{"id":"Cust_371c35ec-34d9-4315-ab31-7ea8889a419a","name":"John"}"#,
     );
-
 }

--- a/src/serde_serialize.rs
+++ b/src/serde_serialize.rs
@@ -31,16 +31,14 @@ pub fn deserialize_raw<'de, O: Identifiable, D: Deserializer<'de>>(
 
 #[cfg(test)]
 mod test {
-    use crate::{Id, Ided};
-    use crate::{IdClass, Identifiable};
-    use kind_proc::Kind;
+    use crate::{Id, IdClass, Ided, Identifiable};
     use rstest::rstest;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
     const ID: &str = "86261271-0fc7-46d3-81c6-0b0158628331";
 
-    #[derive(Debug, Kind, Serialize, Deserialize)]
+    #[derive(Debug, Identifiable, Serialize, Deserialize)]
     #[kind(class = "Test")]
     struct TestStruct {
         pub field: String,


### PR DESCRIPTION
The purpose of the derive macro is to implement the `Identifiable` trait.

In such case, Rust's convention is to give it the same name as the trait. It would also help understand what the derive call does and why.

This PR rename the derive.