### PR TITLE
version 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v1.0.0 - 2024-02-26
+<a name="1.0.0"></a>
+- Kind is complete and has been used with no know issue for more than a year
 
 ### v0.3.0 - 2024-02-16
 <a name="0.3.0"></a>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["kind_proc"]
 
 [package]
 name = "kind"
-version = "0.3.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.65"
 description = "Costless typed identifiers backed by UUID, with kind readable in serialized versions"
@@ -22,7 +22,7 @@ serde = ["dep:serde", "dep:serde_json"]
 sqlx = ["dep:sqlx"]
 
 [dependencies]
-kind_proc = { path = "kind_proc", version = "0.3.0" }
+kind_proc = { path = "kind_proc", version = "1.0.0" }
 schemars = { optional = true, version = "0.8.16" }
 serde = { optional = true, version = "1.0", features = ["derive"] }
 serde_json = { optional = true, version = "1.0" }

--- a/kind_proc/Cargo.toml
+++ b/kind_proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kind_proc"
-version = "0.3.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.65"
 description = "procedural macro for the 'kind' crate"


### PR DESCRIPTION
We've used it in prod for more than one year with zero problem.
It's feature complete and there's no pending request.
There's no reason not to call it a V1.